### PR TITLE
Add domain for FlexColorScheme documentation site

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -22,5 +22,9 @@
 	[
 		"gorouter.dev",
 		"csells/go_router"
+	],
+	[
+		"docs.flexcolorscheme.com",
+		"rydmike/flex_color_scheme_docs"
 	]
 ]


### PR DESCRIPTION
This documentation site is for the open source Flutter FlexColorScheme package https://pub.dev/packages/flex_color_scheme, having its code repo on GitHub here https://github.com/rydmike/flex_color_scheme.

I decided to keep the documentation in a separate repo for increased documentation change flexibility, and to not burden the code repo with documentation images and animated GIFs. The documentation content is still work in progress. I expect to complete it during next week and then publish the stable version of FlexColorScheme v5.0.0 that the documentation site is intended for.

**Question**: I might not use the www CNAME for this site for anything, **if so**, is it OK if I point it to the doc site and add it as another domain too?